### PR TITLE
added keyword sizes mixin for spacers, margins, and paddings

### DIFF
--- a/scss/fulcrum.scss
+++ b/scss/fulcrum.scss
@@ -14,4 +14,5 @@
         './modules/flex-align-items',
         './modules/font-size',
         './modules/text-transform',
+        './modules/keyword-sizes',
         './modules/font-color';

--- a/scss/modules/_keyword-sizes.scss
+++ b/scss/modules/_keyword-sizes.scss
@@ -1,0 +1,46 @@
+$keywords: (
+  small: 15,
+  medium: 30,
+  large: 45,
+  x-large: 60,
+);
+
+$positions: (
+  top,
+  bottom,
+  right,
+  left,
+);
+
+$utilTypes: (
+  padding,
+  margin,
+  spacer,
+);
+
+@mixin keywordSizes {
+  @each $utilType in $utilTypes {
+    @each $keyword, $size in $keywords {
+      @if ($utilType == 'spacer') {
+        .u-spacer-#{$keyword} {
+          &#{&} {
+            clear: both;
+            height: #{$size}px;
+          }
+        }
+      } @else {
+        @each $position in $positions {
+          .u-#{$utilType}-#{$position}-#{$keyword} {
+            &#{&} {
+              #{$utilType}-#{$position}: #{$size}px;
+            }
+          }
+        }
+      }
+    }
+  }
+};
+
+
+
+@include keywordSizes();


### PR DESCRIPTION
- Added keyword values for spacers, margin, and padding
- **Syntax:**
  - **Spacers:** `u-spacer-[keyword]`
  - **Margin/Padding:** `u-[margin|padding]-[keyword]`

keyword | value
--- | ---
small | 15px
medium | 30px
large | 45px
x-large | 60px