### PR TITLE
Updated flex grid to fix issues #29 & #30

### DIFF
--- a/scss/modules/_flex-grid.scss
+++ b/scss/modules/_flex-grid.scss
@@ -1,9 +1,11 @@
+@import './breakpoints';
+
 $columns: 12;
 $space-between: 15px;
-$sizes: (
-  small,
-  medium,
-  large,
+$SIZES: (
+  large: 992,
+  medium: 768,
+  small: 576,
 );
 
 @function stripUnit($value) {
@@ -21,14 +23,23 @@ $sizes: (
       flex-basis: $flexBasis;
       max-width: $flexBasis;
       min-width: $flexBasis;
+      @if ($column == 12) {
+        margin: 0;
+      }
     }
   }
 }
 
 @mixin createSizeClasses {
-  @each $size in $sizes {
+  @each $size, $value in $SIZES {
     &--#{$size} {
-      @include createColumns;
+      @if ($size != 'large') {
+        @media screen and (max-width: #{$value}px) {
+          @include createColumns;
+        }
+      } @else {
+        @include createColumns;
+      }
     }
   }
 }


### PR DESCRIPTION
- Added breakpoints for medium and small screen sizes

- Adjusted order of sizes to cascade properly

- Added breakpoint sizes to SIZES map

- Renamed 'sizes' var to 'SIZES' as it's a constant