### PR TITLE
updated flex-align-mixin

### DIFF
--- a/scss/modules/_flex-align-items.scss
+++ b/scss/modules/_flex-align-items.scss
@@ -1,22 +1,28 @@
 // For item alignment with a flex container
 
 @mixin flexAlignItems {
+  $alignmentTypes: (
+    align,
+    justify,
+  );
+  $alignmentTargets: (
+    items,
+    content,
+  );
   $elementAlignment: (
     start,
     end,
     center,
   );
-  @each $alignment in $elementAlignment {
-    @if $alignment == start or $alignment == end {
-      .u-align-items-#{$alignment} {
-        &#{&} {
-          align-items: flex-#{$alignment};
-        }
-      }
-    } @else {
-      .u-align-items-#{$alignment} {
-        &#{&} {
-          align-items: $alignment;
+  @each $alignmentType in $alignmentTypes {
+    @each $alignmentTarget in $alignmentTargets {
+      .u-#{$alignmentType}-#{$alignmentTarget} {
+        @each $alignment in $elementAlignment {
+          &-#{$alignment} {
+            &#{&} {
+              #{$alignmentType}-#{$alignmentTarget}: #{if(($alignment == start or $alignment == end), flex-#{$alignment}, $alignment)};
+            }
+          }
         }
       }
     }

--- a/scss/modules/_flex-align-items.scss
+++ b/scss/modules/_flex-align-items.scss
@@ -20,6 +20,7 @@
         @each $alignment in $elementAlignment {
           &-#{$alignment} {
             &#{&} {
+              display: flex;
               #{$alignmentType}-#{$alignmentTarget}: #{if(($alignment == start or $alignment == end), flex-#{$alignment}, $alignment)};
             }
           }


### PR DESCRIPTION
Adjusted flex-align mixin to allow for not only `align-items` but also `align-content|justify-content|justify-items` for better usability. These all carry a weight of 020